### PR TITLE
Fix code scanning alert no. 1: Potentially unsafe call to strncat

### DIFF
--- a/src/BBox/qHull/global.cpp
+++ b/src/BBox/qHull/global.cpp
@@ -249,7 +249,7 @@ void qh_initflags(char *command) {
 
   if (command != &qh qhull_command[0]) {
     *qh qhull_command = '\0';
-    strncat(qh qhull_command, command, sizeof(qhull_command) - strlen(qhull_command) - 1);
+    strncat(qh qhull_command, command, sizeof(qh qhull_command) - strlen(qh qhull_command) - 1);
   }
   while (*s && !isspace(*s)) /* skip program name */
     s++;


### PR DESCRIPTION
Fixes [https://github.com/mlund/spheretree/security/code-scanning/1](https://github.com/mlund/spheretree/security/code-scanning/1)

To fix the problem, we need to ensure that the `strncat` function uses the remaining space in the destination buffer. This can be done by subtracting the current length of the destination string from the total buffer size and then subtracting one more to account for the null terminator.

- Update the `strncat` call to use the remaining space in the buffer.
- Specifically, change the third argument of `strncat` to `sizeof(qh_qhull_command) - strlen(qh_qhull_command) - 1`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
